### PR TITLE
Mark the new '<meta>' sections with comments

### DIFF
--- a/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -28,6 +28,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " Highwire Press meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ) );
 
 	my $tags = $plugin->convert_dataobj( $dataobj, "no_cache" => 1 );
 	for my $tag (@{$tags})

--- a/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/plugins/EPrints/Plugin/Export/Prism.pm
@@ -28,6 +28,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " PRISM meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ) );
 
 	$links->appendChild( $plugin->{session}->make_element(
 		"link",


### PR DESCRIPTION
This makes it a bit clearer when scanning through the rather extensive `<head>` section which bits are associated with which specification. This is particularly useful pre-3.4.6 where the `name` and `content` are semi-randomly ordered (and the same appears to currently be true for 3.5.0-beta-1).

While these tags are absolutely not designed for humans to read it feels unnecessary to actively avoid human readability so this is a very small change to help slightly if scanning through the tags (which also makes it easier to see which tags a particular repository has enabled).