### PR TITLE
Improve the consistency of keywords in metatags

### DIFF
--- a/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -142,7 +142,20 @@ sub convert_dataobj
 			push @tags, [ 'citation_editor', EPrints::Utils::make_name_string( $editor ) ] if defined $editor;
 		}
 	}
-	push @tags, [ 'citation_keywords', $eprint->get_value( 'keywords' ) ] if $eprint->exists_and_set( 'keywords' );
+
+	if( $eprint->exists_and_set( 'keywords' ) ) {
+		my $keywords = '';
+		# Keywords should be separated by semicolons according to Zotero so
+		# this converts newlines and commas into semicolons (with consistent
+		# spacing)
+		for my $keyword (split /[\n,;]/, $eprint->get_value( 'keywords' )) {
+			# Trim leading and trailing spaces
+			$keyword =~ s/^\s+|\s+$//g;
+			$keywords .= '; ' if $keywords ne '';
+			$keywords .= $keyword;
+		}
+		push @tags, [ 'citation_keywords', $keywords ];
+	}
 
 	push @tags, [ 'citation_journal_article', $eprint->get_value( 'article_number' ) ] if $eprint->exists_and_set( 'article_number' );
 

--- a/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/plugins/EPrints/Plugin/Export/Prism.pm
@@ -123,10 +123,20 @@ sub convert_dataobj
 
 	# 4.2.24 prism:event
 	push @tags, [ 'prism.event', $eprint->get_value( 'event_title' ) ] if $eprint->exists_and_set( 'event_title' );
-	# 4.2.39 prism:keyword
-	push @tags, [ 'prism.keyword', $eprint->get_value( 'keywords' ) ] if $eprint->exists_and_set( 'keywords' );
 	# 4.2.41 prism:link
 	push @tags, [ 'prism.link', $eprint->get_value( 'official_url' ) ] if $eprint->exists_and_set( 'official_url' );
+
+	if( $eprint->exists_and_set( 'keywords' ) ) {
+		my $keywords = $eprint->get_value( 'keywords' );
+		# There should be zero or more instances of 'prism:keyword' so we split
+		# our keywords on newlines, commas and semicolons
+		for my $keyword (split /[\n,;]/, $keywords) {
+			# Trim leading and trailing spaces
+			$keyword =~ s/^\s+|\s+$//g;
+			# 4.2.39 prism:keyword
+			push @tags, [ 'prism.keyword', $keyword ];
+		}
+	}
 
 	return \@tags;
 }


### PR DESCRIPTION
'keywords' is just a general text field in EPrints (for better or probably worse) however metatag parsing programs will prefer certain styles. To aid in this, PRISM has been changed to split on ',', ';' and '\n' and Highwire Press has been changed to convert ',' and '\n' into ';'.

Fixes #7.