### PR TITLE
Fixes various date-based meta tags

### DIFF
--- a/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -252,6 +252,11 @@ sub get_earliest_date
 			$early_date = parse_date( $eprint->get_value( 'date' ) );
 		}
 	}
+	# Assume that if there is no date_type field then date is a publication date.
+	if( ! $eprint->{dataset}->has_field( 'date_type' ) || ! $eprint->get_value( 'date_type' ) )
+	{
+		$early_date = parse_date( $eprint->get_value( 'date' ) );
+	}
 	return $early_date unless $eprint->exists_and_set( 'dates' );
 
 	for my $date (@{$eprint->get_value( 'dates' )}) {

--- a/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/plugins/EPrints/Plugin/Export/Prism.pm
@@ -79,8 +79,6 @@ sub convert_dataobj
 	# (https://www.w3.org/submissions/2020/SUBM-prism-20200910/prism-basic.html#_Toc46322886)
 
 	my $publication_date = $plugin->get_earliest_date( $eprint, 'published', 'published_online' );
-	# 4.2.14 prism:coverDate
-	push @tags, [ 'prism.coverDate', $publication_date ] if defined $publication_date;
 	# 4.2.59 prism:publicationDate
 	push @tags, [ 'prism.publicationDate', $publication_date ] if defined $publication_date;
 	# 4.2.17 prism:dateReceived
@@ -193,6 +191,11 @@ sub get_earliest_date
 			$early_date = parse_date( $eprint->get_value( 'date' ) );
 		}
 	}
+	# Assume that if there is no date_type field then date is a publication date.
+	if( ! $eprint->{dataset}->has_field( 'date_type' ) || ! $eprint->get_value( 'date_type' ) )
+	{
+		$early_date = parse_date( $eprint->get_value( 'date' ) );
+	}
 	return $early_date unless $eprint->exists_and_set( 'dates' );
 
 	for my $date (@{$eprint->get_value( 'dates' )}) {
@@ -220,7 +223,7 @@ sub parse_date
 	my( $date ) = @_;
 
 	my $parsed_date;
-	if( defined $date && $date =~ m/^(\d+(?:-\d+(?:-\d+)?)?)(?: (\d+:\d+:\d+))/ ) {
+	if( defined $date && $date =~ m/^(\d+(?:-\d+(?:-\d+)?)?)(?: (\d+:\d+:\d+))?/ ) {
 		$parsed_date = $1;
 		$parsed_date .= "T$2" if defined $2;
 	}


### PR DESCRIPTION
1. Assumes date field is publication date if no date_type field or it is not set (for both HighwirePress and Prism). 
2. Fixes Prism parse_date function so it works for dates as welll as datetimes. 
3. Removes Prism's coverDate meta tag as this will always be the same as publicationDate.